### PR TITLE
Use Strongly typed objects for persistence

### DIFF
--- a/Sources/libhostmon/Format.swift
+++ b/Sources/libhostmon/Format.swift
@@ -38,3 +38,21 @@ struct Format {
         ].compactMap { $0 }.joined()
     }
 }
+
+extension OperatingSystemVersion: Encodable {
+
+    enum CodingKeys: String, CodingKey {
+        case major, minor, patch
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.majorVersion, forKey: .major)
+        try container.encode(self.minorVersion, forKey: .minor)
+        try container.encode(self.patchVersion, forKey: .patch)
+    }
+
+    var asDouble: Double {
+        Double(self.patchVersion + self.minorVersion * 100 + self.majorVersion * 10_000)
+    }
+}

--- a/Sources/libhostmon/model/CPULoad.swift
+++ b/Sources/libhostmon/model/CPULoad.swift
@@ -29,12 +29,12 @@ public struct CPULoad: Codable {
         self.nice = nice
     }
 
-    var asDictionary: [String: Double] {
+    var asKeyValuePairs: [KeyValuePair] {
         [
-            "user": self.user,
-            "system": self.system,
-            "idle": self.idle,
-            "nice": self.nice
+            KeyValuePair(key: "user", value: .double(self.user)),
+            KeyValuePair(key: "system", value: .double(self.system)),
+            KeyValuePair(key: "idle", value: .double(self.idle)),
+            KeyValuePair(key: "nice", value: .double(self.nice))
         ]
     }
 }

--- a/Sources/libhostmon/model/DiskUsage.swift
+++ b/Sources/libhostmon/model/DiskUsage.swift
@@ -4,10 +4,10 @@ public struct DiskUsage: Codable {
     public let availableCapacity: UInt64
     public let totalCapacity: UInt64
 
-    var asDictionary: [String: UInt64] {
+    var asKeyValuePairs: [KeyValuePair] {
         [
-            "available": self.availableCapacity,
-            "total": self.totalCapacity
+            KeyValuePair(key: "available", value: .uInt64(self.availableCapacity)),
+            KeyValuePair(key: "total", value: .uInt64(self.totalCapacity))
         ]
     }
 }

--- a/Sources/libhostmon/model/MemoryUsage.swift
+++ b/Sources/libhostmon/model/MemoryUsage.swift
@@ -18,12 +18,12 @@ public struct MemoryUsage: Codable {
         )
     }
 
-    public var asDictionary: [String: UInt64] {
+    public var asKeyValuePairs: [KeyValuePair] {
         [
-            "free": self.freeBytes,
-            "active": self.activeBytes,
-            "wired": self.wiredBytes,
-            "compressed": self.compressedBytes
+            KeyValuePair(key: "free", value: .uInt64(self.freeBytes)),
+            KeyValuePair(key: "active", value: .uInt64(self.activeBytes)),
+            KeyValuePair(key: "wired", value: .uInt64(self.wiredBytes)),
+            KeyValuePair(key: "compressed", value: .uInt64(self.compressedBytes))
         ]
     }
 }

--- a/Sources/libhostmon/model/NetworkUsage.swift
+++ b/Sources/libhostmon/model/NetworkUsage.swift
@@ -16,13 +16,13 @@ public struct NetworkUsage: Codable {
         self.timeframe = TimeInterval(current.timestamp - previous.timestamp)
     }
 
-    var asDictionary: [String: Double] {
+    var asKeyValuePairs: [KeyValuePair] {
         [
-            "bytes-sent": Double(self.bytesSent),
-            "bytes-received": Double(self.bytesReceieved),
-
-            "bytes-sent-per-second": Double(self.bytesSent) / self.timeframe,
-            "bytes-received-per-second": Double(self.bytesReceieved) / self.timeframe
+            KeyValuePair(key: "bytes-sent", value: .uInt32(self.bytesSent)),
+            KeyValuePair(key: "bytes-received", value: .uInt32(self.bytesReceieved)),
+            KeyValuePair(key: "timeframe", value: .timeInterval(self.timeframe)),
+            KeyValuePair(key: "bytes-sent-per-second", value: .double(Double(self.bytesSent) / self.timeframe)),
+            KeyValuePair(key: "bytes-received-per-second", value: .double(Double(self.bytesReceieved) / self.timeframe))
         ]
     }
 }

--- a/Sources/libhostmon/model/SensorService.swift
+++ b/Sources/libhostmon/model/SensorService.swift
@@ -30,8 +30,12 @@ public struct TemperatureSensorValue: Codable {
     public let temperature: Int
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: DynamicKey.self)
-        try container.encode(self.temperature, forKey: DynamicKey(stringValue: self.sensorName))
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        try container.encode(self.temperature, forKey: DynamicCodingKey(stringValue: self.sensorName))
+    }
+
+    var asKeyValuePair: KeyValuePair {
+        KeyValuePair(key: self.sensorName, value: .int(self.temperature))
     }
 }
 
@@ -40,22 +44,12 @@ public struct FanSpeedValue: Codable {
     public let rpm: Int
 
     public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: DynamicKey.self)
-        try container.encode(self.rpm, forKey: DynamicKey(stringValue: self.fanName))
-    }
-}
-
-struct DynamicKey: CodingKey {
-    var intValue: Int?
-    init?(intValue: Int) {
-        self.intValue = intValue
-        self.stringValue = String(intValue)
+        var container = encoder.container(keyedBy: DynamicCodingKey.self)
+        try container.encode(self.rpm, forKey: DynamicCodingKey(stringValue: self.fanName))
     }
 
-    var stringValue: String
-    init(stringValue: String) {
-        self.intValue = nil
-        self.stringValue = stringValue
+    var asKeyValuePair: KeyValuePair {
+        KeyValuePair(key: self.fanName, value: .int(self.rpm))
     }
 }
 

--- a/Sources/libhostmon/model/StatsPackage.swift
+++ b/Sources/libhostmon/model/StatsPackage.swift
@@ -109,21 +109,3 @@ public struct StatsPackage: Encodable {
         try container.encode(fanMap, forKey: .fanSpeeds)
     }
 }
-
-extension OperatingSystemVersion: Encodable {
-
-    enum CodingKeys: String, CodingKey {
-        case major, minor, patch
-    }
-
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.majorVersion, forKey: .major)
-        try container.encode(self.minorVersion, forKey: .minor)
-        try container.encode(self.patchVersion, forKey: .patch)
-    }
-
-    var asDouble: Double {
-        Double(self.patchVersion + self.minorVersion * 100 + self.majorVersion * 10_000)
-    }
-}

--- a/Sources/libhostmon/model/encoding/DynamicCodingKey.swift
+++ b/Sources/libhostmon/model/encoding/DynamicCodingKey.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A dynamic `CodingKey` useful for creating custom `Encodable` implementations
+struct DynamicCodingKey: CodingKey {
+    var intValue: Int?
+    init?(intValue: Int) {
+        self.intValue = intValue
+        self.stringValue = String(intValue)
+    }
+
+    var stringValue: String
+    init(stringValue: String) {
+        self.intValue = nil
+        self.stringValue = stringValue
+    }
+}

--- a/Sources/libhostmon/model/encoding/KeyValuePair.swift
+++ b/Sources/libhostmon/model/encoding/KeyValuePair.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// An object that makes it easy to pass around a strongly-typed heterogenous collection of values
+///
+public struct KeyValuePair: Encodable {
+
+    public enum ValueType: Encodable {
+        case int(Int)
+        case int32(Int32)
+        case timeInterval(TimeInterval)
+        case double(Double)
+        case string(String)
+        case uInt32(UInt32)
+        case uInt64(UInt64)
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            switch self {
+            case .int(let value): try container.encode(value)
+            case .int32(let value): try container.encode(value)
+            case .timeInterval(let value): try container.encode(value)
+            case .double(let value): try container.encode(value)
+            case .string(let value): try container.encode(value)
+            case .uInt32(let value): try container.encode(value)
+            case .uInt64(let value): try container.encode(value)
+            }
+        }
+    }
+
+    public let key: String
+    public let value: ValueType
+
+    init(key: String, value: ValueType) {
+        self.key = key
+        self.value = value
+    }
+
+    enum CodingKeys: CodingKey {
+        case key
+        case value
+    }
+}
+
+extension [KeyValuePair] {
+    func prependingKeysWith(_ prefix: String) -> [KeyValuePair] {
+        self.map { KeyValuePair(key: prefix + $0.key, value: $0.value) }
+    }
+}


### PR DESCRIPTION
Instead of encoding everything to a dictionary, instead return strongly-typed values that can be JSON-encoded with their original types intact